### PR TITLE
Added some public methods to the handler

### DIFF
--- a/Sources/BothamPullToRefreshHandler.swift
+++ b/Sources/BothamPullToRefreshHandler.swift
@@ -18,9 +18,14 @@ public class BothamPullToRefreshHandler: NSObject {
     }
 
     public func addTo(scrollView: UIScrollView) {
-        refreshControl.addTarget(self, action:Selector("refresh:"), forControlEvents:.ValueChanged)
+        refreshControl.addTarget(self, action:Selector("refresh:"), forControlEvents: .ValueChanged)
         scrollView.addSubview(refreshControl)
         scrollView.alwaysBounceVertical = true
+    }
+
+    public func remove() {
+        refreshControl.removeTarget(self, action:Selector("refresh:"), forControlEvents: .ValueChanged)
+        refreshControl.removeFromSuperview()
     }
 
     func refresh(refreshControl: UIRefreshControl)
@@ -30,5 +35,10 @@ public class BothamPullToRefreshHandler: NSObject {
 
     public func endRefreshing() {
         self.refreshControl.endRefreshing()
+    }
+
+    public func beginRefreshing(scrollView: UIScrollView) {
+        scrollView.setContentOffset(CGPoint(x: 0, y: -refreshControl.frame.size.height), animated: true)
+        self.refreshControl.beginRefreshing()
     }
 }


### PR DESCRIPTION
After i have a UITableView with a BothamPullToRefreshHandler already added, i need to remove this pullToRefresh. (its a weird case i know, but its what happened to me now). 

And also i added a method to start refreshing programatically the refreshControl.

@pedrovgs 
