### PR TITLE
Presenter as objc object

### DIFF
--- a/BothamUIUnitTests/DummyViewController.swift
+++ b/BothamUIUnitTests/DummyViewController.swift
@@ -10,4 +10,5 @@ import UIKit
 import BothamUI
 
 class DummyViewController: BothamViewController {
+    var presenter: SpyPresenter!
 }

--- a/BothamUIUnitTests/SpyPresenter.swift
+++ b/BothamUIUnitTests/SpyPresenter.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BothamUI
 
-class SpyPresenter: BothamPresenter {
+class SpyPresenter: NSObject, BothamPresenter {
 
     var executedStages: [Stage] = []
 

--- a/Example/Example/CharacterDetailPresenter.swift
+++ b/Example/Example/CharacterDetailPresenter.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BothamUI
 
-class CharacterDetailPresenter: BothamPresenter {
+class CharacterDetailPresenter: NSObject, BothamPresenter {
     let ui: CharacterDetailUI
 
     init(ui: CharacterDetailUI) {

--- a/Example/Example/CharactersPresenter.swift
+++ b/Example/Example/CharactersPresenter.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BothamUI
 
-class CharactersPresenter: BothamPresenter, BothamPullToRefreshPresenter {
+class CharactersPresenter: NSObject, BothamPresenter, BothamPullToRefreshPresenter {
     private weak var ui: CharactersUI?
     private let wireframe: CharactersWireframe
 

--- a/Example/Example/CharactersViewController.swift
+++ b/Example/Example/CharactersViewController.swift
@@ -15,6 +15,7 @@ class CharactersViewController: ExampleViewController, BothamTableViewController
     @IBOutlet var tableView: UITableView!
     var dataSource: BothamTableViewDataSource<Character, CharacterTableViewCell>!
     var delegate: UITableViewDelegate!
+    var presenter: CharactersPresenter!
 
     override func viewDidLoad() {
         tableView.dataSource = dataSource

--- a/Example/Example/SeriesDetailPresenter.swift
+++ b/Example/Example/SeriesDetailPresenter.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BothamUI
 
-class SeriesDetailPresenter: BothamPresenter {
+class SeriesDetailPresenter: NSObject, BothamPresenter {
 
     private let seriesName: String
     private weak var ui: SeriesDetailUI?

--- a/Example/Example/SeriesDetailViewController.swift
+++ b/Example/Example/SeriesDetailViewController.swift
@@ -19,6 +19,7 @@ private struct Config {
 class SeriesDetailViewController: ExampleViewController, BothamCollectionViewController, SeriesDetailUI {
 
     var dataSource: SeriesDetailCollectionViewDataSource!
+    var presenter: SeriesDetailPresenter!
 
     @IBOutlet weak var collectionView: UICollectionView!
 

--- a/Example/Example/SeriesPresenter.swift
+++ b/Example/Example/SeriesPresenter.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BothamUI
 
-class SeriesPresenter: BothamPresenter, BothamNavigationPresenter {
+class SeriesPresenter: NSObject, BothamPresenter, BothamNavigationPresenter {
 
     private weak var ui: SeriesUI?
     private let wireframe: SeriesWireframe

--- a/Example/Example/SeriesViewController.swift
+++ b/Example/Example/SeriesViewController.swift
@@ -15,6 +15,7 @@ class SeriesViewController: ExampleViewController, BothamTableViewController, Se
     @IBOutlet var tableView: UITableView!
     var dataSource: BothamTableViewDataSource<Series, SeriesTableViewCell>!
     var delegate: UITableViewDelegate!
+    var presenter: SeriesPresenter!
 
     override func viewDidLoad() {
         configureTableView()

--- a/Sources/BothamPresenter.swift
+++ b/Sources/BothamPresenter.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol BothamPresenter {
+public protocol BothamPresenter: NSObjectProtocol {
     func viewDidLoad()
     func viewWillAppear()
     func viewDidAppear()

--- a/Sources/BothamViewController.swift
+++ b/Sources/BothamViewController.swift
@@ -11,31 +11,34 @@ import Foundation
     import UIKit
 
 public class BothamViewController: UIViewController, BothamUI {
-    public var presenter: BothamPresenter! = nil
+    private var _presenter: BothamPresenter? = nil
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        presenter.viewDidLoad()
+        if self.respondsToSelector(Selector("presenter")) {
+            _presenter = self.performSelector(Selector("presenter")).takeUnretainedValue() as? BothamPresenter
+        }
+        _presenter?.viewDidLoad()
     }
 
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        presenter.viewWillAppear()
+        _presenter?.viewWillAppear()
     }
 
     public override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
-        presenter.viewDidAppear()
+        _presenter?.viewDidAppear()
     }
 
     public override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
-        presenter.viewWillDisappear()
+        _presenter?.viewWillDisappear()
     }
 
     public override func viewDidDisappear(animated: Bool) {
         super.viewDidDisappear(animated)
-        presenter.viewDidDisappear()
+        _presenter?.viewDidDisappear()
     }
 }
 #elseif os(OSX)


### PR DESCRIPTION
Because having presenter as generics inside ViewController is not an option.
I propose an alternative solution, that instead of having property to force to be initialized. We dynamically check if the current ViewController has a property called Presenter that implement BothamPresenter. And call the corresponding methods.

caveats:
- We have explicitly define the presenter in each ViewController.
- Presenter should implement NSObject(or at least be visible in @objc)
