### PR TITLE
Refresh control

### DIFF
--- a/Example/Example/CharactersViewController.swift
+++ b/Example/Example/CharactersViewController.swift
@@ -24,4 +24,13 @@ class CharactersViewController: ExampleViewController, BothamTableViewController
         pullToRefreshHandler.addTo(tableView)
         super.viewDidLoad()
     }
+    
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+        pullToRefreshHandler.beginRefreshing()
+        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(3 * Double(NSEC_PER_SEC)))
+        dispatch_after(delayTime, dispatch_get_main_queue()) {
+            self.pullToRefreshHandler.beginRefreshing()
+        }
+    }
 }

--- a/Example/Example/CharactersViewController.swift
+++ b/Example/Example/CharactersViewController.swift
@@ -21,16 +21,7 @@ class CharactersViewController: ExampleViewController, BothamTableViewController
         tableView.delegate = delegate
         tableView.tableFooterView = UIView()
         tableView.accessibilityLabel = "CharactersTableView"
-        pullToRefreshHandler.addTo(tableView)
+        pullToRefreshHandler.setTo(tableView)
         super.viewDidLoad()
-    }
-    
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-        pullToRefreshHandler.beginRefreshing()
-        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(3 * Double(NSEC_PER_SEC)))
-        dispatch_after(delayTime, dispatch_get_main_queue()) {
-            self.pullToRefreshHandler.beginRefreshing()
-        }
     }
 }

--- a/Sources/BothamPullToRefreshHandler.swift
+++ b/Sources/BothamPullToRefreshHandler.swift
@@ -9,8 +9,10 @@
 import Foundation
 
 public class BothamPullToRefreshHandler: NSObject {
-    let presenter: BothamPullToRefreshPresenter
-    let refreshControl = UIRefreshControl()
+    private let presenter: BothamPullToRefreshPresenter
+    private let refreshControl = UIRefreshControl()
+    private var scrollView: UIScrollView?
+    
 
     public init(presenter: BothamPullToRefreshPresenter) {
         self.presenter = presenter
@@ -18,6 +20,7 @@ public class BothamPullToRefreshHandler: NSObject {
     }
 
     public func addTo(scrollView: UIScrollView) {
+        self.scrollView = scrollView
         refreshControl.addTarget(self, action:#selector(BothamPullToRefreshHandler.refresh(_:)), forControlEvents: .ValueChanged)
         scrollView.addSubview(refreshControl)
         scrollView.alwaysBounceVertical = true
@@ -36,8 +39,14 @@ public class BothamPullToRefreshHandler: NSObject {
         self.refreshControl.endRefreshing()
     }
 
-    public func beginRefreshing(scrollView: UIScrollView) {
-        scrollView.setContentOffset(CGPoint(x: 0, y: -refreshControl.frame.size.height), animated: true)
-        self.refreshControl.beginRefreshing()
+    public func beginRefreshing() {
+        if scrollView?.contentOffset.y == 0 {
+            scrollView?.setContentOffset(CGPoint(x: 0, y: -refreshControl.frame.size.height), animated: true)
+            self.refreshControl.beginRefreshing()
+        }
+    }
+    
+    public func isRefreshing() -> Bool {
+        return self.refreshControl.refreshing
     }
 }

--- a/Sources/BothamPullToRefreshHandler.swift
+++ b/Sources/BothamPullToRefreshHandler.swift
@@ -13,13 +13,16 @@ public class BothamPullToRefreshHandler: NSObject {
     private let refreshControl = UIRefreshControl()
     private var scrollView: UIScrollView?
     
-
     public init(presenter: BothamPullToRefreshPresenter) {
         self.presenter = presenter
         super.init()
     }
 
-    public func addTo(scrollView: UIScrollView) {
+    public var isRefreshing: Bool {
+        return self.refreshControl.refreshing
+    }
+
+    public func setTo(scrollView: UIScrollView) {
         self.scrollView = scrollView
         refreshControl.addTarget(self, action:#selector(BothamPullToRefreshHandler.refresh(_:)), forControlEvents: .ValueChanged)
         scrollView.addSubview(refreshControl)
@@ -44,9 +47,5 @@ public class BothamPullToRefreshHandler: NSObject {
             scrollView?.setContentOffset(CGPoint(x: 0, y: -refreshControl.frame.size.height), animated: true)
             self.refreshControl.beginRefreshing()
         }
-    }
-    
-    public func isRefreshing() -> Bool {
-        return self.refreshControl.refreshing
     }
 }

--- a/Sources/BothamPullToRefreshHandler.swift
+++ b/Sources/BothamPullToRefreshHandler.swift
@@ -40,7 +40,7 @@ public class BothamPullToRefreshHandler: NSObject {
     }
 
     public func beginRefreshing() {
-        if scrollView?.contentOffset.y == 0 {
+        if !refreshControl.refreshing {
             scrollView?.setContentOffset(CGPoint(x: 0, y: -refreshControl.frame.size.height), animated: true)
             self.refreshControl.beginRefreshing()
         }


### PR DESCRIPTION
1- When calling two times programatically beginRefreshing the spinner was having some issues (dissapearing, and unknown behaviours), so check if is not already refreshing before starting.

2- When adding the refreshControl is better to store the scrollView to not have later to pass it again when removing the refresh.

3- Added a public method to be able to check if is already refreshing 
