### PR TITLE
Force cocoapods 0.39 install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ env:
 before_install:
   - brew install swiftlint
   - gem install xcpretty
-  - gem install cocoapods
   - gem install xcpretty-travis-formatter
+
+install:
+  - pod _0.39.0_ install
 
 script:
   - swiftlint

--- a/Podfile
+++ b/Podfile
@@ -7,18 +7,18 @@ target 'BothamUIUnitTests' do
     pod 'Nimble'
 end
 
-target 'Example', :exclusive => true do
+target 'Example' do
         xcodeproj 'Example/Example.xcodeproj'
     pod 'BothamUI', :path => './'
     pod 'SDWebImage', '~>3.7'
 end
 
-target 'ExampleTests', :exclusive => true do
+target 'ExampleTests' do
     xcodeproj 'Example/Example.xcodeproj'
     pod "Nimble"
 end
 
-target 'ExampleAcceptanceTests', :exclusive => true do
+target 'ExampleAcceptanceTests' do
         xcodeproj 'Example/Example.xcodeproj'
     pod 'BothamUI', :path => "./"
     pod 'Nimble'


### PR DESCRIPTION
Cocoapods 1.0.0 still has open issues like https://github.com/kif-framework/KIF/issues/848 so we need to force an installation with an outdated version
